### PR TITLE
Add other_deps so pandas and sklearn not required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,14 @@ keras_deps = [
     'tensorflow_datasets~=4.2.0',
     'tensorflow-privacy~=0.5.0',
 ]
+other_deps = [
+    'pandas~=1.1.0',
+    'scikit-learn~=0.23.0',
+]
 pytorch_deps = [
     'opacus~=0.10.0',
     'Pillow~=8.0.1',
+    'scikit-learn~=0.23.0',
     'scipy~=1.5.0',
     'torch~=1.7.0',
     'torchsummary~=1.5.0',
@@ -42,8 +47,8 @@ grpc_deps = ['grpcio~=1.35.0',
              'grpcio-tools~=1.35.0',
              'prometheus_client==0.9.0',
              'click'
-            ]
-all_deps = keras_deps + pytorch_deps + grpc_deps
+             ]
+all_deps = list(set(keras_deps + other_deps + pytorch_deps + grpc_deps))
 
 long_description = ""
 try:
@@ -71,13 +76,12 @@ setuptools.setup(
         'google-cloud-storage~=1.35.0',
         'matplotlib~=3.3.0',
         'numpy~=1.16.0',
-        'pandas~=1.1.0',
         'pydantic~=1.7.0',
-        'scikit-learn~=0.23.0',
     ],
     tests_require=["tox~=3.20.0"],
     extras_require={
         'keras': keras_deps,
+        'other': other_deps,
         'pytorch': pytorch_deps,
         'docs': docs_deps,
         'all': all_deps,

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ envlist = flake8, mypy, pylint, pytest, docs, copyright_check
 
 [testenv]
 basepython = python3.7
-extras = keras,pytorch
+extras = keras,pytorch,other
 whitelist_externals = /bin/sh
 
 [testenv:pytest]


### PR DESCRIPTION
Added an "other" option for install so that the required install doesn't include pandas and sklearn. Numpy and matplotlib are still required for plotting.