### PR TITLE
Feature/learner updates

### DIFF
--- a/colearn_keras/keras_learner.py
+++ b/colearn_keras/keras_learner.py
@@ -87,7 +87,7 @@ class KerasLearner(MachineLearningInterface):
         compile_args = self.model._get_compile_args()  # pylint: disable=protected-access
         opt_config = self.model.optimizer.get_config()
 
-        compile_args['optimizer'] = getattr(keras.optimizers, 
+        compile_args['optimizer'] = getattr(keras.optimizers,
                                             opt_config['name']).from_config(opt_config)
 
         self.model.compile(**compile_args)

--- a/colearn_keras/keras_learner.py
+++ b/colearn_keras/keras_learner.py
@@ -81,7 +81,7 @@ class KerasLearner(MachineLearningInterface):
         Recompiles the Keras model. This way the optimizer history get erased,
         which is needed before a new training round, otherwise the outdated history is used.
         """
-        compile_args = self.model._get_compile_args()
+        compile_args = self.model._get_compile_args()  # pylint: disable=protected-access
         opt_config = self.model.optimizer.get_config()
 
         if opt_config['name'] == 'Adadelta':
@@ -91,7 +91,7 @@ class KerasLearner(MachineLearningInterface):
         elif opt_config['name'] == 'Adam':
             compile_args['optimizer'] = keras.optimizers.Adam.from_config(opt_config)
         elif opt_config['name'] == 'Adamax':
-            compile_args['optimizer'] = keras.optimizers.Adamax.from_config(opt_config)  
+            compile_args['optimizer'] = keras.optimizers.Adamax.from_config(opt_config)
         elif opt_config['name'] == 'Ftrl':
             compile_args['optimizer'] = keras.optimizers.Ftrl.from_config(opt_config)
         elif opt_config['name'] == 'Nadam':
@@ -114,7 +114,8 @@ class KerasLearner(MachineLearningInterface):
         :return: Weights after training
         """
         current_weights = self.mli_get_current_weights()
-        self.recompile_model() # erase the outdated optimizer memory (momentums mostly)
+        # erase the outdated optimizer memory (momentums mostly)
+        self.recompile_model()
         self.train()
         new_weights = self.mli_get_current_weights()
         self.set_weights(current_weights)

--- a/colearn_keras/test_keras_learner.py
+++ b/colearn_keras/test_keras_learner.py
@@ -28,6 +28,8 @@ def get_mock_model() -> mock.Mock:
     model.evaluate.return_value = {"loss": 1,
                                    "accuracy": 3}
     model.get_weights.return_value = "all the weights"
+    model.optimizer.get_config.return_value = {"name": "Adam"}
+    model._get_compile_args.return_value = {}
     return model
 
 

--- a/colearn_keras/test_keras_learner.py
+++ b/colearn_keras/test_keras_learner.py
@@ -29,7 +29,7 @@ def get_mock_model() -> mock.Mock:
                                    "accuracy": 3}
     model.get_weights.return_value = "all the weights"
     model.optimizer.get_config.return_value = {"name": "Adam"}
-    model._get_compile_args.return_value = {}
+    model._get_compile_args.return_value = {}  # pylint: disable=protected-access
     return model
 
 

--- a/colearn_pytorch/pytorch_learner.py
+++ b/colearn_pytorch/pytorch_learner.py
@@ -16,6 +16,7 @@
 #
 # ------------------------------------------------------------------------------
 from typing import Optional, Callable
+from collections import defaultdict
 
 try:
     import torch
@@ -100,6 +101,9 @@ class PytorchLearner(MachineLearningInterface):
         """
         Trains the model on the training dataset
         """
+
+        # erase the outdated optimizer memory (momentums mostly)
+        self.optimizer.__setstate__({'state': defaultdict(dict)})
 
         self.model.train()
 

--- a/colearn_pytorch/pytorch_learner.py
+++ b/colearn_pytorch/pytorch_learner.py
@@ -94,10 +94,7 @@ class PytorchLearner(MachineLearningInterface):
         :param weights: Weights to be stored
         """
 
-        with torch.no_grad():
-            for new_param, old_param in zip(weights.weights,
-                                            self.model.parameters()):
-                old_param.set_(new_param)
+        self.model.load_state_dict(weights.weights)
 
     def train(self):
         """

--- a/colearn_pytorch/pytorch_learner.py
+++ b/colearn_pytorch/pytorch_learner.py
@@ -84,7 +84,7 @@ class PytorchLearner(MachineLearningInterface):
 
         current_state_dict = OrderedDict()
         for key in self.model.state_dict():
-            current_state_dict[key] = self.model.state_dict()[key].clone()    
+            current_state_dict[key] = self.model.state_dict()[key].clone()
         w = Weights(weights=current_state_dict)
 
         return w

--- a/colearn_pytorch/pytorch_learner.py
+++ b/colearn_pytorch/pytorch_learner.py
@@ -16,7 +16,7 @@
 #
 # ------------------------------------------------------------------------------
 from typing import Optional, Callable
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 
 try:
     import torch
@@ -82,7 +82,7 @@ class PytorchLearner(MachineLearningInterface):
         :return: The current weights of the model
         """
 
-        current_state_dict = {}
+        current_state_dict = OrderedDict()
         for key in self.model.state_dict():
             current_state_dict[key] = self.model.state_dict()[key].clone()    
         w = Weights(weights=current_state_dict)

--- a/colearn_pytorch/pytorch_learner.py
+++ b/colearn_pytorch/pytorch_learner.py
@@ -81,7 +81,11 @@ class PytorchLearner(MachineLearningInterface):
         :return: The current weights of the model
         """
 
-        w = Weights(weights=[x.clone() for x in self.model.parameters()])
+        current_state_dict = {}
+        for key in self.model.state_dict():
+            current_state_dict[key] = self.model.state_dict()[key].clone()    
+        w = Weights(weights=current_state_dict)
+
         return w
 
     def set_weights(self, weights: Weights):

--- a/colearn_pytorch/test_pytorch_learner.py
+++ b/colearn_pytorch/test_pytorch_learner.py
@@ -15,7 +15,7 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-from unittest.mock import Mock, MagicMock, create_autospec
+from unittest.mock import Mock, create_autospec
 from collections import OrderedDict
 
 import pytest
@@ -27,7 +27,7 @@ from colearn.ml_interface import Weights
 from colearn_pytorch.pytorch_learner import PytorchLearner
 
 # torch does not correctly type-hint its tensor class so pylint fails
-MODEL_PARAMETERS = OrderedDict({'param1':torch.tensor([3, 3]), 'param2': torch.tensor([4, 4])})  # pylint: disable=not-callable
+MODEL_PARAMETERS = OrderedDict({'param1': torch.tensor([3, 3]), 'param2': torch.tensor([4, 4])})  # pylint: disable=not-callable
 MODEL_PARAMETERS2 = OrderedDict({'param1': torch.tensor([5, 5]), 'param2': torch.tensor([6, 6])})  # pylint: disable=not-callable
 BATCH_SIZE = 2
 TRAIN_BATCHES = 1

--- a/colearn_pytorch/test_pytorch_learner.py
+++ b/colearn_pytorch/test_pytorch_learner.py
@@ -15,7 +15,8 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-from unittest.mock import Mock, create_autospec
+from unittest.mock import Mock, MagicMock, create_autospec
+from collections import OrderedDict
 
 import pytest
 import torch
@@ -26,8 +27,8 @@ from colearn.ml_interface import Weights
 from colearn_pytorch.pytorch_learner import PytorchLearner
 
 # torch does not correctly type-hint its tensor class so pylint fails
-MODEL_PARAMETERS = [torch.tensor([3, 3]), torch.tensor([4, 4])]  # pylint: disable=not-callable
-MODEL_PARAMETERS2 = [torch.tensor([5, 5]), torch.tensor([6, 6])]  # pylint: disable=not-callable
+MODEL_PARAMETERS = OrderedDict({'param1':torch.tensor([3, 3]), 'param2': torch.tensor([4, 4])})  # pylint: disable=not-callable
+MODEL_PARAMETERS2 = OrderedDict({'param1': torch.tensor([5, 5]), 'param2': torch.tensor([6, 6])})  # pylint: disable=not-callable
 BATCH_SIZE = 2
 TRAIN_BATCHES = 1
 TEST_BATCHES = 1
@@ -36,7 +37,7 @@ LOSS = 12
 
 def get_mock_model() -> Mock:
     model = create_autospec(torch.nn.Module, instance=True, spec_set=True)
-    model.parameters.return_value = [x.clone() for x in MODEL_PARAMETERS]
+    model.state_dict.return_value = MODEL_PARAMETERS
     model.to.return_value = model
     return model
 
@@ -54,7 +55,9 @@ def get_mock_dataloader() -> Mock:
 
 
 def get_mock_optimiser() -> Mock:
-    return Mock()
+    opt = Mock()
+    opt.__setstate__ = Mock()
+    return opt
 
 
 def get_mock_criterion() -> Mock:
@@ -82,7 +85,7 @@ def nkl():
 
 
 def test_setup(nkl):
-    assert str(MODEL_PARAMETERS) == str(nkl.model.parameters())
+    assert str(MODEL_PARAMETERS) == str(nkl.mli_get_current_weights().weights)
     vote_score = LOSS / (TEST_BATCHES * BATCH_SIZE)
     assert nkl.vote_score == vote_score
 
@@ -108,17 +111,12 @@ def test_vote_minimise_criterion(nkl):
     assert nkl.vote(vote_score - 0.1) is False
 
 
-def test_accept_weights(nkl):
-    nkl.mli_accept_weights(Weights(weights=MODEL_PARAMETERS2))
-    assert str(nkl.model.parameters()) == str(MODEL_PARAMETERS2)
-
-
 def test_propose_weights(nkl):
-    current_weights = nkl.model.parameters()
+    current_weights = nkl.mli_get_current_weights()
     proposed_weights = nkl.mli_propose_weights()
     assert isinstance(proposed_weights, Weights)
     # current weights should not change
-    assert str(current_weights) == str(nkl.model.parameters())
+    assert str(current_weights) == str(proposed_weights)
     # proposed_weights should be different from current_weights, but I cannot
     # find a way to test this!
 
@@ -127,4 +125,3 @@ def test_get_current_weights(nkl):
     weights = nkl.mli_get_current_weights()
     assert isinstance(weights, Weights)
     assert str(weights.weights) == str(MODEL_PARAMETERS)
-    assert str(weights.weights) == str(nkl.model.parameters())


### PR DESCRIPTION
Two changes:
1.) The `mli_get_current_weights` returns all trainable and non-trainable parameters. Previously only the trainable parameters were returned for PyTochLearner, but normalization layers have non-trainable parameters, which are needed too to reproduce the model performance. See running statistics [here](https://pytorch.org/docs/stable/generated/torch.nn.BatchNorm2d.html).
2.) Erase optimizer history at the beginning of the `mli_propose_weights`, which is more general, as history gets outdated when others improve the model.

The learner test files were also modified, accordingly.