### PR TITLE
differential privacy & privacy budget monitoring for the learners

### DIFF
--- a/colearn_keras/keras_learner.py
+++ b/colearn_keras/keras_learner.py
@@ -26,6 +26,8 @@ except ImportError:
 from tensorflow import keras
 
 from colearn.ml_interface import MachineLearningInterface, Weights, ProposedWeights
+from tensorflow_privacy.privacy.analysis.compute_dp_sgd_privacy import compute_dp_sgd_privacy
+from tensorflow_privacy.privacy.optimizers.dp_optimizer_keras import make_keras_optimizer_class
 
 
 class KerasLearner(MachineLearningInterface):
@@ -39,6 +41,7 @@ class KerasLearner(MachineLearningInterface):
                  need_reset_optimizer: bool = True,
                  minimise_criterion: bool = True,
                  criterion: str = 'loss',
+                 privacy_kwargs: Optional[dict] = None,
                  model_fit_kwargs: Optional[dict] = None,
                  model_evaluate_kwargs: Optional[dict] = None):
         """
@@ -48,6 +51,8 @@ class KerasLearner(MachineLearningInterface):
         :param need_reset_optimizer: True to clear optimizer history before training, False to kepp history.
         :param minimise_criterion: Boolean - True to minimise value of criterion, False to maximise
         :param criterion: Function to measure model performance
+        :param privacy_kwargs: dict - Stores the differential privacy budget related constants.
+                                      When set to None, no differential privacy applied.
         :param model_fit_kwargs: Arguments to be passed on model.fit function call
         :param model_evaluate_kwargs: Arguments to be passed on model.evaluate function call
         """
@@ -57,6 +62,7 @@ class KerasLearner(MachineLearningInterface):
         self.need_reset_optimizer = need_reset_optimizer
         self.minimise_criterion: bool = minimise_criterion
         self.criterion = criterion
+
         self.model_fit_kwargs = model_fit_kwargs or {}
 
         if model_fit_kwargs:
@@ -66,6 +72,18 @@ class KerasLearner(MachineLearningInterface):
                 sig.bind_partial(**self.model_fit_kwargs)
             except TypeError:
                 raise Exception("Invalid arguments for model.fit")
+
+        self.privacy_kwargs = privacy_kwargs
+
+        if self.privacy_kwargs:
+            for k in ['epsilon', 'delta']:
+                assert k in self.privacy_kwargs.keys()
+            self.epsilon_spent = 0
+            self.cumulative_epochs = 0
+            if 'epochs' in self.model_fit_kwargs.keys():
+                self.epochs_per_fit = self.model_fit_kwargs['epochs']
+            else:
+                self.epochs_per_fit = signature(self.model.fit).parameters['epochs'].default
 
         self.model_evaluate_kwargs = model_evaluate_kwargs or {}
 
@@ -87,8 +105,22 @@ class KerasLearner(MachineLearningInterface):
         compile_args = self.model._get_compile_args()  # pylint: disable=protected-access
         opt_config = self.model.optimizer.get_config()
 
-        compile_args['optimizer'] = getattr(keras.optimizers,
-                                            opt_config['name']).from_config(opt_config)
+        if self.privacy_kwargs:
+            # tensorflow_privacy optimizers get_config() miss the additional parameters
+            # was fixed here: https://github.com/tensorflow/privacy/commit/49db04e3561638fc02795edb5774d322cdd1d7d1
+            # but it is not yet in the stable version, thus I need here to do the same.
+            opt_config.update({
+                'l2_norm_clip': self.model.optimizer._l2_norm_clip,  # pylint: disable=protected-access
+                'noise_multiplier': self.model.optimizer._noise_multiplier,  # pylint: disable=protected-access
+                'num_microbatches': self.model.optimizer._num_microbatches,  # pylint: disable=protected-access
+            })
+            new_opt = make_keras_optimizer_class(
+                getattr(keras.optimizers, opt_config['name'])
+            ).from_config(opt_config)
+            compile_args['optimizer'] = new_opt
+        else:
+            compile_args['optimizer'] = getattr(keras.optimizers,
+                                                opt_config['name']).from_config(opt_config)
 
         self.model.compile(**compile_args)
 
@@ -99,9 +131,21 @@ class KerasLearner(MachineLearningInterface):
         :return: Weights after training
         """
         current_weights = self.mli_get_current_weights()
+        if self.privacy_kwargs:
+            # we calculate epsilon beforehand, to save unnecessary model training
+            epsilon = self.privacy_after_training()
+            if epsilon < self.privacy_kwargs['epsilon']:
+                # if the budget would be overconsumed, reject training
+                return current_weights
+
         self.train()
         new_weights = self.mli_get_current_weights()
         self.set_weights(current_weights)
+
+        if self.privacy_kwargs:
+            self.update_spent_privacy(epsilon)
+            self.cumulative_epochs += self.epochs_per_fit
+
         return new_weights
 
     def mli_test_weights(self, weights: Weights) -> ProposedWeights:
@@ -147,6 +191,31 @@ class KerasLearner(MachineLearningInterface):
         """
         self.set_weights(weights)
         self.vote_score = self.test(self.train_loader)
+
+    def privacy_after_training(self) -> float:
+        """
+        Calculates, what epsilon will apply after another model training.
+        """
+        batch_size = self.train_loader._batch_size.numpy()  # pylint: disable=protected-access
+        iterations_per_epoch = tf.data.experimental.cardinality(self.train_loader).numpy()
+        n_samples = batch_size * iterations_per_epoch
+        planned_epochs = self.cumulative_epochs + self.epochs_per_fit
+
+        epsilon, _ = compute_dp_sgd_privacy(
+            n=n_samples,
+            batch_size=batch_size,
+            noise_multiplier=self.model.optimizer._noise_multiplier,  # pylint: disable=protected-access
+            epochs=planned_epochs,
+            delta=self.privacy_kwargs['delta']
+        )
+        return epsilon
+
+    def update_spent_privacy(self, epsilon: float):
+        """
+        Keep the privacy budget updated.
+        :param epsilon: epsilon to be stored.
+        """
+        self.epsilon_spent = epsilon
 
     def mli_get_current_weights(self) -> Weights:
         """

--- a/colearn_keras/keras_learner.py
+++ b/colearn_keras/keras_learner.py
@@ -73,12 +73,12 @@ class KerasLearner(MachineLearningInterface):
             except TypeError:
                 raise Exception("Invalid arguments for model.fit")
 
-        self.privacy_kwargs = privacy_kwargs
+        self.privacy_kwargs = privacy_kwargs or {}
 
         if self.privacy_kwargs:
             for k in ['epsilon', 'delta']:
                 assert k in self.privacy_kwargs.keys()
-            self.epsilon_spent = 0
+            self.epsilon_spent = 0.0
             self.cumulative_epochs = 0
             if 'epochs' in self.model_fit_kwargs.keys():
                 self.epochs_per_fit = self.model_fit_kwargs['epochs']

--- a/colearn_keras/keras_learner.py
+++ b/colearn_keras/keras_learner.py
@@ -134,7 +134,7 @@ class KerasLearner(MachineLearningInterface):
         if self.privacy_kwargs:
             # we calculate epsilon beforehand, to save unnecessary model training
             epsilon = self.privacy_after_training()
-            if epsilon < self.privacy_kwargs['epsilon']:
+            if epsilon > self.privacy_kwargs['epsilon']:
                 # if the budget would be overconsumed, reject training
                 return current_weights
 

--- a/colearn_keras/test_keras_learner.py
+++ b/colearn_keras/test_keras_learner.py
@@ -78,3 +78,15 @@ def test_get_current_weights(nkl):
     weights = nkl.mli_get_current_weights()
     assert isinstance(weights, Weights)
     assert weights.weights == get_mock_model().get_weights.return_value
+
+def test_privacy_budget():
+    # exceeded
+    # note exceeded
+
+def test_optimizer_reset():
+    # with privacy
+    # without privacy
+
+def test_privacy():
+    # turned off
+    # turned on

--- a/colearn_keras/test_keras_learner.py
+++ b/colearn_keras/test_keras_learner.py
@@ -44,8 +44,6 @@ def get_mock_model() -> Mock:
 
 def get_mock_dataloader() -> Mock:
     dl = tf.data.Dataset.range(42)
-    dl._batch_size = Mock()  # pylint: disable=protected-access
-    dl._batch_size.numpy.return_value = 16  # pylint: disable=protected-access
     return dl
 
 
@@ -54,7 +52,8 @@ def nkl():
     """Returns a Keraslearner"""
     model = get_mock_model()
     dl = get_mock_dataloader()
-    nkl = KerasLearner(model, dl, privacy_kwargs={'epsilon': 1, 'delta': 1e-3})
+    nkl = KerasLearner(model, dl, privacy_kwargs={'epsilon': 1, 'delta': 1e-3,
+                                                  'batch_size': 16})
     return nkl
 
 


### PR DESCRIPTION
Add support for differential privacy model training, with the following features/options:
 - let the user set a privacy budget
 - monitor privacy loss
 - when more training is not possible within the budget, stop training
 - support optimizer reset too

work in progress