### PR TITLE
Move onnx export to learners & minor train/vote/test set fixes

### DIFF
--- a/colearn/ml_interface.py
+++ b/colearn/ml_interface.py
@@ -20,32 +20,7 @@ from enum import Enum
 from typing import Any, Optional
 
 import onnx
-import onnxmltools
-import sklearn
-import tensorflow as tf
-import torch
 from pydantic import BaseModel
-from tensorflow import keras
-
-model_classes_keras = (tf.keras.Model, keras.Model, tf.estimator.Estimator)
-model_classes_scipy = (torch.nn.Module)
-model_classes_sklearn = (sklearn.base.ClassifierMixin)
-
-
-def convert_model_to_onnx(model: Any):
-    """
-    Helper function to convert a ML model to onnx format
-    """
-    if isinstance(model, model_classes_keras):
-        return onnxmltools.convert_keras(model)
-    if isinstance(model, model_classes_sklearn):
-        return onnxmltools.convert_sklearn(model)
-    if 'xgboost' in model.__repr__():
-        return onnxmltools.convert_sklearn(model)
-    if isinstance(model, model_classes_scipy):
-        raise Exception("Pytorch models not yet supported to onnx")
-    else:
-        raise Exception("Attempt to convert unsupported model to onnx: {model}")
 
 
 class DiffPrivBudget(BaseModel):

--- a/colearn_examples/ml_interface/mli_fraud.py
+++ b/colearn_examples/ml_interface/mli_fraud.py
@@ -115,7 +115,7 @@ class FraudLearner(MachineLearningInterface):
         return ColearnModel(
             model_format=ModelFormat(ModelFormat.ONNX),
             model_file="",
-            model=onnxmltools.convert_sklearn(self.model, initial_types=[('input', FloatTensorType([1, self.train_data.shape[1]]))]),
+            model=onnxmltools.convert_sklearn(self.model, initial_types=[('input', FloatTensorType([None, self.train_data.shape[1]]))]),
         )
 
     def mli_get_current_weights(self):

--- a/colearn_examples/ml_interface/mli_fraud.py
+++ b/colearn_examples/ml_interface/mli_fraud.py
@@ -21,10 +21,12 @@ import sys
 from pathlib import Path
 
 import numpy as np
+import onnxmltools
+from onnxmltools.convert.common.data_types import FloatTensorType
 import sklearn
 from sklearn.linear_model import SGDClassifier
 
-from colearn.ml_interface import MachineLearningInterface, Weights, ProposedWeights, ColearnModel, ModelFormat, convert_model_to_onnx
+from colearn.ml_interface import MachineLearningInterface, Weights, ProposedWeights, ColearnModel, ModelFormat
 from colearn.training import initial_result, collective_learning_round, set_equal_weights
 from colearn.utils.plot import ColearnPlot
 from colearn.utils.results import Results, print_results
@@ -113,7 +115,7 @@ class FraudLearner(MachineLearningInterface):
         return ColearnModel(
             model_format=ModelFormat(ModelFormat.ONNX),
             model_file="",
-            model=convert_model_to_onnx(self.model),
+            model=onnxmltools.convert_sklearn(self.model, initial_types=[('input', FloatTensorType([1, self.train_data.shape[1]]))]),
         )
 
     def mli_get_current_weights(self):

--- a/colearn_examples/ml_interface/mli_random_forest_iris.py
+++ b/colearn_examples/ml_interface/mli_random_forest_iris.py
@@ -19,10 +19,12 @@ import os
 import pickle
 
 import numpy as np
+import onnxmltools
+from onnxmltools.convert.common.data_types import FloatTensorType
 from sklearn import datasets
 from sklearn.ensemble import RandomForestClassifier
 
-from colearn.ml_interface import MachineLearningInterface, Weights, ProposedWeights, ColearnModel, ModelFormat, convert_model_to_onnx
+from colearn.ml_interface import MachineLearningInterface, Weights, ProposedWeights, ColearnModel, ModelFormat
 from colearn.training import initial_result, collective_learning_round
 from colearn.utils.plot import ColearnPlot
 from colearn.utils.results import Results, print_results
@@ -105,7 +107,7 @@ class IrisLearner(MachineLearningInterface):
         return ColearnModel(
             model_format=ModelFormat(ModelFormat.ONNX),
             model_file="",
-            model=convert_model_to_onnx(self.model),
+            model=onnxmltools.convert_sklearn(self.model, initial_types=[('input', FloatTensorType([None, self.train_data.shape[1]]))]),
         )
 
     def set_weights(self, weights: Weights):

--- a/colearn_examples/ml_interface/xgb_reg_boston.py
+++ b/colearn_examples/ml_interface/xgb_reg_boston.py
@@ -18,12 +18,14 @@
 import os
 from typing import Optional
 
+import onnxmltools
+from onnxmltools.convert.common.data_types import FloatTensorType
 from sklearn import datasets
 from sklearn.metrics import mean_squared_error as mse
 import numpy as np
 import xgboost as xgb
 
-from colearn.ml_interface import MachineLearningInterface, Weights, ProposedWeights, ColearnModel, ModelFormat, convert_model_to_onnx
+from colearn.ml_interface import MachineLearningInterface, Weights, ProposedWeights, ColearnModel, ModelFormat
 from colearn.training import initial_result, collective_learning_round
 from colearn.utils.data import split_list_into_fractions
 from colearn.utils.plot import ColearnPlot
@@ -106,7 +108,7 @@ class XGBoostLearner(MachineLearningInterface):
         return ColearnModel(
             model_format=ModelFormat(ModelFormat.ONNX),
             model_file="",
-            model=convert_model_to_onnx(self.model),
+            model=onnxmltools.convert_xgboost(self.model, initial_types=[('input', FloatTensorType([None, self.xg_train.num_col()]))]),
         )
 
     def test(self, data_matrix):

--- a/colearn_keras/keras_learner.py
+++ b/colearn_keras/keras_learner.py
@@ -18,6 +18,7 @@
 from inspect import signature
 from typing import Optional
 
+import onnxmltools
 try:
     import tensorflow as tf
 except ImportError:
@@ -25,7 +26,7 @@ except ImportError:
                     "add-ons please install colearn with `pip install colearn[keras]`.")
 from tensorflow import keras
 
-from colearn.ml_interface import MachineLearningInterface, Weights, ProposedWeights, ColearnModel, ModelFormat, convert_model_to_onnx
+from colearn.ml_interface import MachineLearningInterface, Weights, ProposedWeights, ColearnModel, ModelFormat
 from colearn.ml_interface import DiffPrivBudget, DiffPrivConfig, TrainingSummary, ErrorCodes
 from tensorflow_privacy.privacy.analysis.compute_dp_sgd_privacy import compute_dp_sgd_privacy
 from tensorflow_privacy.privacy.optimizers.dp_optimizer_keras import make_keras_optimizer_class
@@ -245,7 +246,7 @@ class KerasLearner(MachineLearningInterface):
         return ColearnModel(
             model_format=ModelFormat(ModelFormat.ONNX),
             model_file="",
-            model=convert_model_to_onnx(self.model),
+            model=onnxmltools.covert_keras(self.model),
         )
 
     def set_weights(self, weights: Weights):

--- a/colearn_keras/keras_mnist.py
+++ b/colearn_keras/keras_mnist.py
@@ -56,7 +56,7 @@ def prepare_loaders_impl(location: str,
     train_loader = _make_loader(images[:n_cases], labels[:n_cases], batch_size, dp_enabled=dp_enabled)
     vote_loader = _make_loader(images[n_cases:n_cases + n_vote_cases], labels[n_cases:n_cases + n_vote_cases],
                                batch_size)
-    test_loader = _make_loader(images[n_cases:], labels[n_cases:], batch_size)
+    test_loader = _make_loader(images[n_cases + n_vote_cases:], labels[n_cases + n_vote_cases:], batch_size)
 
     return train_loader, vote_loader, test_loader
 
@@ -219,7 +219,7 @@ def prepare_learner(data_loaders: Tuple[PrefetchDataset, PrefetchDataset, Prefet
         model=model,
         train_loader=data_loaders[0],
         vote_loader=data_loaders[1],
-        test_loader=data_loaders[1],
+        test_loader=data_loaders[2],
         criterion="sparse_categorical_accuracy",
         minimise_criterion=False,
         model_fit_kwargs={"steps_per_epoch": steps_per_epoch},

--- a/colearn_other/fraud_dataset.py
+++ b/colearn_other/fraud_dataset.py
@@ -21,6 +21,8 @@ import tempfile
 from pathlib import Path
 from typing import Optional, List, Tuple, Generator
 
+import onnxmltools
+from onnxmltools.convert.common.data_types import FloatTensorType
 from sklearn.linear_model import SGDClassifier
 from sklearn.preprocessing import LabelEncoder
 from sklearn.preprocessing import scale
@@ -28,7 +30,7 @@ import sklearn
 import numpy as np
 import pandas as pd
 
-from colearn.ml_interface import MachineLearningInterface, Weights, ProposedWeights, ColearnModel, ModelFormat, convert_model_to_onnx
+from colearn.ml_interface import MachineLearningInterface, Weights, ProposedWeights, ColearnModel, ModelFormat
 from colearn.utils.data import get_data, split_list_into_fractions
 from colearn_grpc.factory_registry import FactoryRegistry
 
@@ -141,7 +143,7 @@ class FraudLearner(MachineLearningInterface):
         return ColearnModel(
             model_format=ModelFormat(ModelFormat.ONNX),
             model_file="",
-            model=convert_model_to_onnx(self.model),
+            model=onnxmltools.convert_sklearn(self.model, initial_types=[('input', FloatTensorType([None, self.train_data.shape[1]]))]),
         )
 
     def set_weights(self, weights: Weights):

--- a/colearn_pytorch/pytorch_covid_xray.py
+++ b/colearn_pytorch/pytorch_covid_xray.py
@@ -74,7 +74,7 @@ def prepare_data_loaders(location: str,
 
     train_loader = _make_loader(data[:n_cases], labels[:n_cases], batch_size, **loader_kwargs)
     vote_loader = _make_loader(data[n_cases:n_cases + n_vote_cases], labels[n_cases:n_cases + n_vote_cases], batch_size)
-    test_loader = _make_loader(data[n_cases:], labels[n_cases:], batch_size, **loader_kwargs)
+    test_loader = _make_loader(data[n_cases + n_vote_cases:], labels[n_cases + n_vote_cases:], batch_size, **loader_kwargs)
 
     return train_loader, vote_loader, test_loader
 

--- a/colearn_pytorch/pytorch_learner.py
+++ b/colearn_pytorch/pytorch_learner.py
@@ -31,7 +31,7 @@ import torch.utils.data
 from torch.nn.modules.loss import _Loss
 
 from colearn.ml_interface import MachineLearningInterface, Weights, ProposedWeights, ColearnModel, \
-    convert_model_to_onnx, ModelFormat
+    ModelFormat
 
 _DEFAULT_DEVICE = torch.device("cpu")
 
@@ -100,10 +100,16 @@ class PytorchLearner(MachineLearningInterface):
         :return: The current model and its format
         """
 
+        torch.onnx.export(
+            self.model,
+            self.train_loader[0],  # example model input
+            'torch_model.onnx',
+        )
+
         return ColearnModel(
             model_format=ModelFormat(ModelFormat.ONNX),
             model_file="",
-            model=convert_model_to_onnx(self.model),
+            model=onnx.load('torch_model.onnx'),
         )
 
     def set_weights(self, weights: Weights):

--- a/colearn_pytorch/pytorch_learner.py
+++ b/colearn_pytorch/pytorch_learner.py
@@ -29,6 +29,7 @@ import torch.optim
 import torch.utils
 import torch.utils.data
 from torch.nn.modules.loss import _Loss
+import onnx
 
 from colearn.ml_interface import MachineLearningInterface, Weights, ProposedWeights, ColearnModel, \
     ModelFormat
@@ -100,9 +101,13 @@ class PytorchLearner(MachineLearningInterface):
         :return: The current model and its format
         """
 
+        _sample_data = None
+        for _sample_data, _ in self.train_loader:
+            break
+
         torch.onnx.export(
             self.model,
-            self.train_loader[0],  # example model input
+            _sample_data,  # example model input
             'torch_model.onnx',
         )
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ keras_deps = [
     'tensorflow>=2.2,<2.8',
     'tensorflow_datasets>=4.2,<4.5',
     'tensorflow-privacy>=0.5,<0.8',
+    'tf2onnx==1.9.3',
 ]
 other_deps = [
     'pandas~=1.1.0',
@@ -77,7 +78,6 @@ setuptools.setup(
         'google-cloud-storage>=1.35,<1.44',
         'matplotlib>=3.3,<3.6',
         'onnx==1.8.1',
-        'tf2onnx==1.9.3',
         'onnxmltools==1.10.0',
         'numpy>=1.16,<1.23',
         'pydantic>=1.7,<1.10',


### PR DESCRIPTION
1.)
Onnx export requires 
 - `initial_types` for sklearn and xgboost, which defines the input data shapes
 - the knowledge if the underlying model is sklearn, xgboost, tf/keras or pytorch
 - input datasize for pytorch models

Due to these requirements, it makes more sense to let the learners define the export, whom are in possession of these information, while the wrapper in the mli_interface is not.

I've seen a JIRA issue for depricate mli*weights, for that: the onnx --> {sklearn; xgboost; pytorch; tf} conversion is needed in the future?

2.)
As there are many examples, when the vote set was introduced, a few were inconsistent. Fixes for them.