### PR TITLE
upgrade tensorflow and dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@
 import setuptools
 
 keras_deps = [
-    'tensorflow>=2.9',
+    'tensorflow>=2.10',
     'tensorflow_datasets>=4.2,<4.5',
     'tensorflow-privacy>=0.5,<0.8',
 ]
@@ -78,7 +78,7 @@ setuptools.setup(
         'google-cloud-storage>=1.35,<2.2',
         'matplotlib>=3.3,<3.6',
         'onnx==1.8.1',
-        'tf2onnx==1.9.3',
+        'tf2onnx==1.13.0',
         'onnxmltools==1.10.0',
         'numpy>=1.16,<1.23',
         'pydantic>=1.7,<1.10',


### PR DESCRIPTION
When running colearn on the latest master on my ubuntu vm I received the following error:

```
docker logs learner-9990
Setting up self signed certificate for domain learner-9990
Generating a RSA private key
.....................................................+++++
..............................+++++
writing new private key to 'server.key'
-----
Running python3 /app/run_grpc_server.py
2022-11-16 08:57:58.527028: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory
2022-11-16 08:57:58.527172: I tensorflow/stream_executor/cuda/cudart_stub.cc:29] Ignore above cudart dlerror if you do not have a GPU set up on your machine.
Traceback (most recent call last):
  File "/app/run_grpc_server.py", line 30, in <module>
    import colearn_keras.keras_mnist  # type:ignore # noqa: F401
  File "/app/colearn/colearn_keras/keras_mnist.py", line 30, in <module>
    from tensorflow_privacy.privacy.optimizers.dp_optimizer_keras import DPKerasAdamOptimizer
  File "/usr/local/lib/python3.7/site-packages/tensorflow_privacy/__init__.py", line 55, in <module>
    from tensorflow_privacy.privacy.dp_query.discrete_gaussian_query import DiscreteGaussianSumQuery
  File "/usr/local/lib/python3.7/site-packages/tensorflow_privacy/privacy/dp_query/discrete_gaussian_query.py", line 20, in <module>
    from tensorflow_privacy.privacy.dp_query import discrete_gaussian_utils
  File "/usr/local/lib/python3.7/site-packages/tensorflow_privacy/privacy/dp_query/discrete_gaussian_utils.py", line 29, in <module>
    import tensorflow_probability as tf_prob
  File "/usr/local/lib/python3.7/site-packages/tensorflow_probability/__init__.py", line 20, in <module>
    from tensorflow_probability import substrates
  File "/usr/local/lib/python3.7/site-packages/tensorflow_probability/substrates/__init__.py", line 17, in <module>
    from tensorflow_probability.python.internal import all_util
  File "/usr/local/lib/python3.7/site-packages/tensorflow_probability/python/__init__.py", line 138, in <module>
    dir(globals()[pkg_name])  # Forces loading the package from its lazy loader.
  File "/usr/local/lib/python3.7/site-packages/tensorflow_probability/python/internal/lazy_loader.py", line 57, in __dir__
    module = self._load()
  File "/usr/local/lib/python3.7/site-packages/tensorflow_probability/python/internal/lazy_loader.py", line 37, in _load
    self._on_first_access()
  File "/usr/local/lib/python3.7/site-packages/tensorflow_probability/python/__init__.py", line 64, in _validate_tf_environment
    present=tf.__version__))
ImportError: This version of TensorFlow Probability requires TensorFlow version >= 2.10; Detected an installation of version 2.9.2. Please upgrade TensorFlow to proceed.
```

By upgrading tensorflow to v2.10 this error was fixed.